### PR TITLE
Fix format security warning

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -391,7 +391,7 @@ bool view_confirm(view_t *view, const char *prompt)
     char ch = 0;
 
     wbkgdset(w, A_REVERSE);
-    if (mvwprintw(w, STATUS_Y, STATUS_X, prompt) == OK)
+    if (mvwprintw(w, STATUS_Y, STATUS_X, "%s", prompt) == OK)
         wclrtoeol(w);
     wrefresh(w);
 


### PR DESCRIPTION
Fixes build error with `-Werror=format-security` (default on arch linux):

```
view.c: In function ‘view_confirm’:
view.c:394:5: error: format not a string literal and no format arguments [-Werror=format-security]
  394 |     if (mvwprintw(w, STATUS_Y, STATUS_X, prompt) == OK)
      |     ^~
cc1: some warnings being treated as errors
make[2]: *** [Makefile:519: evjstest-view.o] Error 1
```